### PR TITLE
fix the issue of using in webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.idea/
 /node_modules/
-/lib/
 /module/
 npm-debug.log
 /temp/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /module/
 npm-debug.log
 /temp/
+*.swp

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,78 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["isElement"] = factory();
+	else
+		root["isElement"] = factory();
+})(this, function() {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	'use strict';
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; /**
+	                                                                                                                                                                                                                                                                               * Returns `true` if provided input is Element.
+	                                                                                                                                                                                                                                                                               * @name isElement
+	                                                                                                                                                                                                                                                                               * @param {*} [input]
+	                                                                                                                                                                                                                                                                               * @returns {boolean}
+	                                                                                                                                                                                                                                                                               */
+
+
+	exports.default = function (input) {
+	  return input != null && (typeof input === 'undefined' ? 'undefined' : _typeof(input)) === 'object' && input.nodeType === Node.ELEMENT_NODE && _typeof(input.style) === 'object' && _typeof(input.ownerDocument) === 'object';
+	};
+
+/***/ }
+/******/ ])
+});
+;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/fczbkk/iselement#readme",
   "main": "lib/index.js",
   "module": "module/index.js",
-  "webpack": "module/index.js",
   "jsnext:main": "module/index.js",
   "scripts": {
     "dev": "npm run test:dev",


### PR DESCRIPTION
Hi, when I use another library with dependencies on this library, and use webpack to bundle js, I found an error. And finally I found it's because this library's package.json file have a specific path of webpack's resolving. The 'module/index.js'  file have higher priority than 'main/index.js' file. But the 'module/index.js' is  a ES6 syntax file. So when I use the bundled file in browser, it will have an error.